### PR TITLE
fix restarting container with enable_docker_plugin=true

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -13,7 +13,7 @@ if [[ $auto_retirement ]]; then
     trap '/usr/bin/mackerel-agent retire -force' TERM KILL
 fi
 
-if [[ $enable_docker_plugin ]]; then
+if [[ $enable_docker_plugin ]] && ! grep "^\[plugin\.metrics\.docker\]" /etc/mackerel-agent/mackerel-agent.conf; then
     echo [plugin.metrics.docker] >> /etc/mackerel-agent/mackerel-agent.conf
     echo command = \"/usr/bin/mackerel-plugin-docker -method API -name-format name\" >> /etc/mackerel-agent/mackerel-agent.conf
 fi


### PR DESCRIPTION
## CASE

Restarting mackerel-agent container with `enable_docker_plugin=true` fails with error below.

```
failed to load config: Failed to load the config file: Near line 121 (last key parsed 'plugin.metrics'): Key 'plugin.metrics.docker' has already been defined.
```
## SOLUTION

Skip appending config if the line exists.
