### PR TITLE
When you restart remove pid files

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -18,6 +18,10 @@ if [[ $enable_docker_plugin ]] && ! grep "^\[plugin\.metrics\.docker\]" /etc/mac
     echo command = \"/usr/bin/mackerel-plugin-docker -method API -name-format name\" >> /etc/mackerel-agent/mackerel-agent.conf
 fi
 
+if [[ -e /var/run/mackerel-agent.pid ]]; then
+    rm -f /var/run/mackerel-agent.pid
+fi
+
 echo /usr/bin/mackerel-agent -apikey=${apikey} $opts
 /usr/bin/mackerel-agent $opts &
 wait ${!}


### PR DESCRIPTION
## en:
Hi, 

I'm not so good at writing English, so I also write in Japansese.
I faced a problem when I restart the container.
As long as I checked, I found the message to delete pid file at the time of restarting.
I modified the code to delete it.

Best regards,

## ja:
ちっす。
私は英語得意じゃないんで日本語でも書くね。
コンテナを再起動したら問題にぶつかったよ。
調べた限りだと再起動した時にpidファイルを削除するようにとのメッセージ出てることに気づいたよ〜。
pidファイルを削除するようコードを修正したんで、宜しく!


## logs:
```
2017/3/13 14:54:082017/03/13 05:54:08 main.go:171: INFO <main> Starting mackerel-agent version:0.41.0, rev:9a152fd, apibase:https://mackerel.io
2017/3/13 14:54:08pidfile.Create("/var/run/mackerel-agent.pid") failed: pidfile found, try stopping another running mackerel-agent or delete /var/run/mackerel-agent.pid
```