### PR TITLE
propagate signals to mackerel-agent

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -16,11 +16,12 @@ fi
 
 # Propagate signals to mackerel-agent.
 if [[ $auto_retirement ]]; then
-    trap '/usr/bin/mackerel-agent retire -force' TERM KILL
+    trap '/usr/bin/mackerel-agent retire -force; kill -SIGTERM $PID' TERM KILL
+else
+    trap 'kill -SIGTERM $PID' TERM
 fi
-trap 'kill -SIGTERM $PID' SIGTERM
-trap 'kill -SIGQUIT $PID' SIGQUIT
-trap 'kill -SIGHUP  $PID' SIGHUP
+trap 'kill -SIGQUIT $PID' QUIT
+trap 'kill -SIGHUP  $PID' HUP
 
 echo /usr/bin/mackerel-agent -apikey=${apikey} $opts
 /usr/bin/mackerel-agent $opts &

--- a/startup.sh
+++ b/startup.sh
@@ -9,15 +9,20 @@ if [[ $include ]]; then
     sed -i -e "s|# Configuration for Custom Metrics Plugins|include = \"${include}\"|" /etc/mackerel-agent/mackerel-agent.conf
 fi
 
-if [[ $auto_retirement ]]; then
-    trap '/usr/bin/mackerel-agent retire -force' TERM KILL
-fi
-
 if [[ $enable_docker_plugin ]] && ! grep "^\[plugin\.metrics\.docker\]" /etc/mackerel-agent/mackerel-agent.conf; then
     echo [plugin.metrics.docker] >> /etc/mackerel-agent/mackerel-agent.conf
     echo command = \"/usr/bin/mackerel-plugin-docker -method API -name-format name\" >> /etc/mackerel-agent/mackerel-agent.conf
 fi
 
+# Propagate signals to mackerel-agent.
+if [[ $auto_retirement ]]; then
+    trap '/usr/bin/mackerel-agent retire -force' TERM KILL
+fi
+trap 'kill -SIGTERM $PID' SIGTERM
+trap 'kill -SIGQUIT $PID' SIGQUIT
+trap 'kill -SIGHUP  $PID' SIGHUP
+
 echo /usr/bin/mackerel-agent -apikey=${apikey} $opts
 /usr/bin/mackerel-agent $opts &
-wait ${!}
+PID=$!
+wait $PID


### PR DESCRIPTION
mackerel-agent supports graseful shutdown, but startup.sh didn't
propagate signals to the agent.

"docker stop" and "docker restart" didn't work correctly because the
signal was not propageted to the agent and the agent cannot execute any
shutdown process (e.g. deleting pid file, posting remaining data to
mackerel server).

related: #11