### PR TITLE
Fix wrong regular expression to enable docker plugin correctly

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -12,7 +12,7 @@ if [ "$include" != "" ]; then
     sed -i -e "s|# Configuration for Custom Metrics Plugins|include = \"${include}\"|" $conf
 fi
 
-if [ "$enable_docker_plugin" != "" ] && [ "$enable_docker_plugin" != "0" ] && ! grep '^[plugin.metrics.docker]' $conf; then
+if [ "$enable_docker_plugin" != "" ] && [ "$enable_docker_plugin" != "0" ] && ! grep '^\[plugin\.metrics\.docker\]' $conf; then
     cat >> $conf << "EOF"
 [plugin.metrics.docker]
 command = "/usr/bin/mackerel-plugin-docker -method API -name-format name"


### PR DESCRIPTION
Commit 29e1a6fe836d2691ee06dbd689d60be158af5538 includes a bug which
makes docker plugin unavailable. It is caused by wrong regular expression
that does not escape '[' '.' ']' with backslash.
This commit rewinds the regexp.